### PR TITLE
Turba OAuth2 - Google contacts sync (Ticket #9481)

### DIFF
--- a/bin/turba-import-google-json
+++ b/bin/turba-import-google-json
@@ -1,0 +1,72 @@
+#!/usr/bin/env php
+<?php
+/**
+ * This script imports JSON data into turba address books.
+ * The address book, user name, and JSON data are
+ * passed as parameters.
+ *
+ * -- TODO -- Copyright 2005-2018 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (ASL).  If you
+ * did not receive this file, see http://www.horde.org/licenses/apache.
+ *
+ * @author Matthew Sharinghousen <matthew.sharinghousen@uni.kn>
+ */
+
+/**
+ *
+ * This file is still in the early stages... Included for completeness... 
+ */
+
+if (file_exists(__DIR__ . '/../../turba/lib/Application.php')) {
+    $baseDir = __DIR__ . '/../';
+} else {
+    require_once 'PEAR/Config.php';
+    $baseDir = PEAR_Config::singleton()
+        ->get('horde_dir', null, 'pear.horde.org') . '/turba/';
+}
+require_once $baseDir . 'lib/Application.php';
+Horde_Registry::appInit('turba', array('cli' => true));
+
+// Read command line parameters.
+if (count($argv) != 3) {
+    $cli->message('Too many or too few parameters.', 'cli.error');
+    usage();
+}
+$user = $argv[1];
+$data = $argv[2];
+
+$registry->setAuth($user, array());
+
+// Check the if the data is valid json
+json_decode(data);
+if (json_last_error() == JSON_ERROR_NONE) {
+    $cli->message('Data is not valid JSON.', 'cli.error');
+    usage();
+}
+
+$vars = Horde_Variables::getDefaultVariables();
+//$vars->set('a', 'Google Contacts');
+
+// Create address book, if not exists
+$addressbook = '';
+//$addressbook = $injector->getInstance('Turba_Shares')->getShare($vars->get('a'));
+if (!$addressbuch) {
+    //$vars = Horde_Variables::getDefaultVariables();
+    $vars->set('name', 'Google Contacts');
+    $vars->set('description', '');
+    $form = new Turba_Form_CreateAddressBook($vars);
+
+    try {
+        $form->execute();
+    } catch (Turba_Exception $e) {
+        $notification->push($e);
+    }
+}
+
+function usage()
+{
+    $GLOBALS['cli']->writeln('Usage: turba-import-google-json user json');
+    exit;
+}
+

--- a/config/conf.xml
+++ b/config/conf.xml
@@ -5,6 +5,8 @@
   <configheader>Menu Settings</configheader>
   <configboolean name="import_export" desc="Should we display an Import/Export
   link in Turba's menu?">true</configboolean>
+  <configboolean name="google_contacts" desc="Should syncing Google Contacts
+  with Oauth2 be allowed? Requires SQL backend">true</configboolean>
  </configsection>
 
  <configsection name="client">

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -206,6 +206,11 @@ class Turba_Application extends Horde_Registry_Application
         if ($GLOBALS['conf']['menu']['import_export']) {
             $menu->add(Horde::url('data.php'), _("_Import/Export"), 'horde-data');
         }
+
+	/* Google Contacts Sync  */
+        if ($GLOBALS['conf']['menu']['google_contacts']) {
+            $menu->add(Horde::url('oauth.php'), _("_Google Sync"));
+        }
     }
 
     /**

--- a/lib/Driver.php
+++ b/lib/Driver.php
@@ -3204,4 +3204,57 @@ class Turba_Driver implements Countable
         }
     }
 
+    /**
+     * Get access/sync tokens for OAuth.
+     *
+     * @param Turba_Driver $driver Contains the system storage driver
+     * @param string $tokenType Determines whether access or sync is retrieved.
+     *
+     * @return array The requested token, if access was successful.
+     */
+    public function getToken($driver, $tokenType)
+    {
+        /**
+         * functionality added here for future implementation in other drivers
+         *   but the user should be notified if they try to use something other than SQL at the moment.
+         */
+        if (get_class($driver->_driver) != 'Turba_Driver_Sql') {
+            throw new Turba_Exception('OAuth only supported by the SQL storage backend');
+        }
+
+        // This shouldn't happen - if it does something is broken.
+        if ($tokenType == '') {
+            throw new Turba_Exception('No OAuth token type specified.');
+        }
+
+        return $driver->_driver->getToken($tokenType);
+    }
+
+    /**
+     * Set access/sync tokens for OAuth.
+     *
+     * @param Turba_Driver $driver Contains the system storage driver
+     * @param string $token The token to be stored.
+     * @param string $tokenType Determines whether access or sync is set.
+     */
+    public function setToken($driver, $token, $tokenType)
+    {
+        /**
+         * functionality added here for future implementation in other drivers
+         *   but the user should be notified if they try to use something other than SQL at the moment.
+         */
+        if (get_class($driver->_driver) != 'Turba_Driver_Sql') {
+            throw new Turba_Exception('OAuth only supported by the SQL storage backend');
+        }
+
+        // This shouldn't happen - if it does something is broken.
+        if ($tokenType == '') {
+            throw new Turba_Exception('No OAuth token type specified.');
+        }
+        if ($token == '') {
+            throw new Turba_Exception('No OAuth token specified.');
+        }
+
+        return $driver->_driver->setToken($token, $tokenType);
+    }
 }

--- a/migration/1_turba_base_tables.php
+++ b/migration/1_turba_base_tables.php
@@ -124,6 +124,16 @@ class TurbaBaseTables extends Horde_Db_Migration_Base
             $this->addIndex('turba_shares_users', array('user_uid'));
             $this->addIndex('turba_shares_users', array('perm'));
         }
+
+	if (!in_array('turba_oauth', $tableList)) {
+            $t = $this->createTable('turba_oauth', array('autoincrementKey' => false));
+            $t->column('owner_id', 'string', array('limit' => 255, 'null' => false));
+            /* Token column should not have a max length, as described by the API */
+            $t->column('oauth_access', 'string', array('null' => false));
+            $t->column('oauth_sync', 'string', array('null' => false));
+            $t->primaryKey(array('owner_id'));
+            $t->end();
+        }
     }
 
     /**

--- a/oauth.php
+++ b/oauth.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * This script handles the user-wise authentication and query of Google Contacts 
+ *
+ * TODO Copyright 2000-2018 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (ASL).  If you did
+ * did not receive this file, see http://www.horde.org/licenses/apache.
+ *
+ * @author Matthew Sharinghousen <matthew.sharinghousen@uni.kn>
+ */
+
+require_once __DIR__ . '/lib/Google/vendor/autoload.php';
+require_once __DIR__ . '/lib/Application.php';
+Horde_Registry::appInit('turba');
+
+$vars = Horde_Variables::getDefaultVariables();
+$vars->set('source', key($addSources));
+$source = $vars->get('source');
+
+// TODO Add a check here for the "Google Contacts" book, if no, then make. Pass as source.
+
+/* A source has been selected, connect. */
+if ($source) {
+    try {
+        $driver = $injector->getInstance('Turba_Factory_Driver')->create($source);
+    } catch (Turba_Exception $e) {
+        $notification->push($e, 'horde.error');
+        $driver = null;
+    }
+}
+
+$access_token = $driver->getToken($driver, 'oauth_access'); 
+
+$client = new Google_Client();
+$client->setAuthConfigFile('client_secrets.json');
+$client->setRedirectUri('http://' . $_SERVER['HTTP_HOST'] . '/turba/oauth.php');
+$client->addScope(Google_Service_People::CONTACTS_READONLY);
+
+//TODO: Add check for token expiration, access is valid for 1 hour
+if (!empty($access_token)) {
+  $accessToken = unserialize($access_token[0]);
+  $syncToken = $driver->getToken($driver, 'oauth_sync')[0];
+
+  //TODO: This list can probably be refined
+  $personFields = 'addresses,ageRanges,biographies,birthdays,emailAddresses,locales,names,nicknames,occupations,organizations,phoneNumbers,relations,residences,skills,urls';
+
+  $client->setAccessToken($accessToken);
+  $connect = new Google_Service_PeopleService($client);
+
+  do {
+    // Meat and potatoes - this is where the contacts are queried, and response contains contacts
+    $connections = $connect->people_connections->
+	  listPeopleConnections('people/me', 
+	  array('pageToken' => $nextPageToken,
+	        'pageSize' => 23, // Increasing size will increase server load/runtime, but reduce number of requests 
+	        'personFields' => $personFields,
+	        'requestSyncToken' => True,
+	        'syncToken' => $syncToken));
+
+    $nextPageToken = $connections->nextPageToken;
+    $syncToken = $connections->nextSyncToken;
+
+  } while ($nextPageToken != '');  
+
+  // Store sync token to save state
+  $driver->setToken($driver, $syncToken, 'oauth_sync'); 
+
+  // Let the user know of success
+  $notification->push(sprintf(_("Google Contacts have been synced")), 'horde.success');
+
+  $redirect_uri = 'http://' . $_SERVER['HTTP_HOST'] . '/turba';
+  header('Location: ' . filter_var($redirect_uri, FILTER_SANITIZE_URL));
+} else {
+  if (! isset($_GET['code'])) {
+    $authUrl = $client->createAuthUrl();
+    header('Location: ' . filter_var($authUrl, FILTER_SANITIZE_URL));
+  } else {
+    $client->authenticate($_GET['code']);
+    $accessToken = serialize($client->getAccessToken());
+
+    $driver->setToken($driver, $accessToken, 'oauth_access');
+
+    $redirect_uri = 'http://' . $_SERVER['HTTP_HOST'] . '/turba/oauth.php';
+    header('Location: ' . filter_var($redirect_uri, FILTER_SANITIZE_URL));
+  }
+}
+?>


### PR DESCRIPTION
Omitted but necessary files: client_secrets.json, Google API package
The secrets file can be obtained by creating a Google People API credential with the callback "<HOST URI>/turba/oauth.php"

The Google package can be downloaded here: 
https://developers.google.com/api-client-library/php/start/installation

This version allows for 1-click downloading of Google contacts. The access and sync tokens are stored in the MySQL backend for future syncs. At the moment, automated syncs have not been implemented. 

The contacts are downloaded in json format, and will eventually be imported into an address book "Google Contacts" via the turba/bin/turba-import-google-json script. (not yet working). 

I look forward to your comments, and I would especially appreciate any hints you might have as to how I can automate the syncing without web-interface interaction. 