### PR TITLE
Fix LDAP_OPT_REFERRALS

### DIFF
--- a/lib/Driver/Ldap.php
+++ b/lib/Driver/Ldap.php
@@ -83,7 +83,7 @@ class Turba_Driver_Ldap extends Turba_Driver
         }
 
         /* Set the LDAP referrals. */
-        if (!empty($this->_params['referrals'])) {
+        if (array_key_exists('referrals', $this->_params)) {
             @ldap_set_option($this->_ds, LDAP_OPT_REFERRALS, $this->_params['referrals']);
         }
 


### PR DESCRIPTION
If `$this->_params['referrals']` is 0, then `empty($this->_params['referrals'])` will be true...