### PR TITLE
phpunit 9.x support

### DIFF
--- a/lib/Driver/Ldap.php
+++ b/lib/Driver/Ldap.php
@@ -698,7 +698,7 @@ class Turba_Driver_Ldap extends Turba_Driver
 
         /* Syntaxes we want to allow, i.e. no integers.
          * Syntaxes have the form:
-         * 1.3.6.1.4.1.1466.115.121.1.$n{$y}
+         * 1.3.6.1.4.1.1466.115.121.1.$n[$y]
          * ... where $n is the integer used below and $y is a sizelimit. */
         $okSyntax = array(
             44 => 1, /* Printable string. */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Turba/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Turba/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde Turba Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Turba/TestCase.php
+++ b/test/Turba/TestCase.php
@@ -29,7 +29,7 @@ require __DIR__ . '/Stub/Hooks.php';
  * @link       http://www.horde.org/apps/turba
  * @license    http://www.horde.org/licenses/apache Apache-like
  */
-class Turba_TestCase extends PHPUnit_Framework_TestCase
+class Turba_TestCase extends Horde_Test_Case
 {
     protected function getInjector()
     {

--- a/test/Turba/ToDo/ApiTest.php
+++ b/test/Turba/ToDo/ApiTest.php
@@ -31,7 +31,7 @@
  */
 class Turba_ToDo_ApiTest extends Turba_TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
     }

--- a/test/Turba/ToDo/BrowsePageTest.php
+++ b/test/Turba/ToDo/BrowsePageTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/TestBase.php';
  */
 class Turba_Todo_BrowsePageTest extends Turba_TestBase {
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/ToDo/DriverTest.php
+++ b/test/Turba/ToDo/DriverTest.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/TestBase.php';
  */
 class Turba_ToDo_DriverTest extends Turba_TestBase {
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/ToDo/GroupTest.php
+++ b/test/Turba/ToDo/GroupTest.php
@@ -11,7 +11,7 @@ class Turba_ToDo_GroupTest extends Turba_TestBase {
 
     var $group;
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/ToDo/KolabTest.php
+++ b/test/Turba/ToDo/KolabTest.php
@@ -14,7 +14,7 @@ class Turba_ToDo_KolabTest extends Turba_KolabTestBase {
      *
      * @return NULL
      */
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         $this->prepareTurba();

--- a/test/Turba/ToDo/ListTest.php
+++ b/test/Turba/ToDo/ListTest.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/TestBase.php';
  */
 class Turba_ToDo_ListTest extends Turba_TestBase {
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/ToDo/ListViewTest.php
+++ b/test/Turba/ToDo/ListViewTest.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/TestBase.php';
  */
 class Turba_ToDo_ListViewTest extends Turba_TestBase {
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/ToDo/ListViewTest.php
+++ b/test/Turba/ToDo/ListViewTest.php
@@ -71,7 +71,7 @@ class Turba_ToDo_ListViewTest extends Turba_TestBase {
         $this->callView_List('getAlpha', $numDisplayed, 'j');
         $count = 0;
         foreach ($this->_sortedByLastname as $name) {
-            if (Horde_String::lower($name{0}) == 'j') {
+            if (Horde_String::lower($name[0]) == 'j') {
                 $this->assertWantedPattern('/' . preg_quote($name, '/') . '/',
                                            $this->_output);
                 $count++;

--- a/test/Turba/ToDo/TestBase.php
+++ b/test/Turba/ToDo/TestBase.php
@@ -6,7 +6,7 @@
  * @package Turba
  * @subpackage UnitTests
  */
-class Turba_TestBase extends PHPUnit_Framework_TestCase {
+class Turba_TestBase extends Horde_Test_Case {
 
     var $_driver;
     var $_driverConfig = array(
@@ -158,7 +158,7 @@ class Turba_TestBase extends PHPUnit_Framework_TestCase {
         return true;
     }
 
-    function setUp()
+    function setUp(): void
     {
         @define('TURBA_BASE', __DIR__ . '/../..');
         @define('TURBA_TEMPLATES', $GLOBALS['registry']->get('templates', 'turba'));

--- a/test/Turba/ToDo/ViewBrowseTest.php
+++ b/test/Turba/ToDo/ViewBrowseTest.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/TestBase.php';
  */
 class Turba_ToDo_ViewBrowseTest extends Turba_TestBase {
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/ToDo/ViewListTest.php
+++ b/test/Turba/ToDo/ViewListTest.php
@@ -71,7 +71,7 @@ class Turba_ToDo_ViewListTest extends Turba_TestBase {
         $this->callView_List('getAlpha', $numDisplayed, 'j');
         $count = 0;
         foreach ($this->_sortedByLastname as $name) {
-            if (Horde_String::lower($name{0}) == 'j') {
+            if (Horde_String::lower($name[0]) == 'j') {
                 $this->assertWantedPattern('/' . preg_quote($name, '/') . '/',
                                            $this->_output);
                 $count++;

--- a/test/Turba/ToDo/ViewListTest.php
+++ b/test/Turba/ToDo/ViewListTest.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/TestBase.php';
  */
 class Turba_ToDo_ViewListTest extends Turba_TestBase {
 
-    function setUp()
+    function setUp(): void
     {
         $this->markTestIncomplete('Convert to use Horde_Test.');
         parent::setUp();

--- a/test/Turba/Unit/Driver/Base.php
+++ b/test/Turba/Unit/Driver/Base.php
@@ -51,14 +51,14 @@ class Turba_Unit_Driver_Base extends Turba_TestCase
      */
     private $_added = array();
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$setup = new Horde_Test_Setup();
         self::createBasicTurbaSetup(self::$setup);
         parent::setUpBeforeClass();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$driver = null;
         self::tearDownBasicTurbaSetup();
@@ -66,7 +66,7 @@ class Turba_Unit_Driver_Base extends Turba_TestCase
         parent::tearDownAfterClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $error = self::$setup->getError();
         if (!empty($error)) {
@@ -75,7 +75,7 @@ class Turba_Unit_Driver_Base extends Turba_TestCase
         $GLOBALS['injector']->setInstance('Turba_Tagger', new Turba_Tagger());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         foreach ($this->_added as $added) {
@@ -113,7 +113,7 @@ class Turba_Unit_Driver_Base extends Turba_TestCase
         if (!class_exists('Horde_ActiveSync')){
             $this->markTestSkipped('ActiveSync not installed.');
         }
-        $state = $this->getMock('Horde_ActiveSync_State_Base', array(), array(), '', false);
+        $state = $this->getMockBuilder('Horde_ActiveSync_State_Base')->disableOriginalConstructor()->getMock();
         $fixture = array(
             'userAgent' => 'Apple-iPad3C6/1202.435',
             'properties' => array(Horde_ActiveSync_Device::OS => 'iOS 8.1.1')

--- a/test/Turba/Unit/Driver/KolabTest.php
+++ b/test/Turba/Unit/Driver/KolabTest.php
@@ -36,14 +36,14 @@ class Turba_Unit_Driver_KolabTest extends Turba_Unit_Driver_Base
 {
     protected $backupGlobals = false;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         return;
         parent::setUpBeforeClass();
         self::$driver = self::createKolabDriverWithShares(self::$setup);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete("No query of type 'Share' registered!");
     }

--- a/test/Turba/Unit/Driver/Sql/Base.php
+++ b/test/Turba/Unit/Driver/Sql/Base.php
@@ -36,7 +36,7 @@ class Turba_Unit_Driver_Sql_Base extends Turba_Unit_Driver_Base
 {
     static $callback;
 
-    static public function setUpBeforeClass()
+    static public function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::getDb();

--- a/test/Turba/Unit/Driver/Sql/Pdo/SqliteTest.php
+++ b/test/Turba/Unit/Driver/Sql/Pdo/SqliteTest.php
@@ -36,7 +36,7 @@ class Turba_Unit_Driver_Sql_Pdo_SqliteTest extends Turba_Unit_Driver_Sql_Base
 {
     protected $backupGlobals = false;
 
-    static public function setUpBeforeClass()
+    static public function setUpBeforeClass(): void
     {
         self::$callback = array(__CLASS__, 'getDb');
         parent::setUpBeforeClass();

--- a/test/Turba/Unit/ExportTest.php
+++ b/test/Turba/Unit/ExportTest.php
@@ -8,21 +8,21 @@
  */
 class Turba_Unit_ExportTest extends Turba_TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::createBasicTurbaSetup(new Horde_Test_Setup());
         parent::setUpBeforeClass();
         setlocale(LC_MESSAGES, 'C');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::tearDownBasicTurbaSetup();
         parent::tearDownAfterClass();
         setlocale(LC_MESSAGES, null);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $GLOBALS['injector']->setInstance(
             'Turba_Tagger',

--- a/test/Turba/Unit/ImportTest.php
+++ b/test/Turba/Unit/ImportTest.php
@@ -22,14 +22,14 @@ class Turba_Unit_ImportTest extends Turba_TestCase
         'workEmail' => 'object_workemail'
     );
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::createBasicTurbaSetup(new Horde_Test_Setup());
         parent::setUpBeforeClass();
         setlocale(LC_MESSAGES, 'C');
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::tearDownBasicTurbaSetup();
         parent::tearDownAfterClass();

--- a/test/Turba/Unit/Turba/Base.php
+++ b/test/Turba/Unit/Turba/Base.php
@@ -48,20 +48,20 @@ class Turba_Unit_Turba_Base extends Turba_TestCase
      */
     protected $default_name = 'Address book of test@example.com';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::createBasicTurbaSetup(self::$setup);
         parent::setUpBeforeClass();
     }
 
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::tearDownBasicTurbaSetup();
         self::tearDownShares();
         parent::tearDownAfterClass();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $error = self::$setup->getError();
         if (!empty($error)) {
@@ -69,7 +69,7 @@ class Turba_Unit_Turba_Base extends Turba_TestCase
         }
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $turba_shares = $GLOBALS['injector']->getInstance('Turba_Shares');
         foreach ($turba_shares->listShares('test@example.com') as $share) {

--- a/test/Turba/Unit/Turba/KolabTest.php
+++ b/test/Turba/Unit/Turba/KolabTest.php
@@ -43,14 +43,14 @@ class Turba_Unit_Turba_KolabTest extends Turba_Unit_Turba_Base
      */
     protected $default_name = 'Contacts';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$setup = new Horde_Test_Setup();
         parent::setUpBeforeClass();
         self::createKolabShares(self::$setup);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->markTestIncomplete("No query of type 'Share' registered!");
     }

--- a/test/Turba/Unit/Turba/Sql/Base.php
+++ b/test/Turba/Unit/Turba/Sql/Base.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../Base.php';
  */
 class Turba_Unit_Turba_Sql_Base extends Turba_Unit_Turba_Base
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::createSqlShares(self::$setup);

--- a/test/Turba/Unit/Turba/Sql/Pdo/SqliteTest.php
+++ b/test/Turba/Unit/Turba/Sql/Pdo/SqliteTest.php
@@ -36,7 +36,7 @@ class Turba_Unit_Turba_Sql_Pdo_SqliteTest extends Turba_Unit_Turba_Sql_Base
 {
     protected $backupGlobals = false;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$setup = new Horde_Test_Setup();
         self::createSqlPdoSqlite(self::$setup);

--- a/test/Turba/phpunit.xml
+++ b/test/Turba/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="bootstrap.php"></phpunit>


### PR DESCRIPTION
- Debian fixes for phpunit 9.x supprt: https://salsa.debian.org/horde-team/php-horde-turba/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian changes: Use square braces for string offset access. https://salsa.debian.org/horde-team/php-horde-turba/-/blob/debian-sid/debian/patches/1002_square-instead-curly-braces-for-string-offset-access.patch
