### PR TITLE
Refactor data retrieval logic for image objects

### DIFF
--- a/lib/View/Browse.php
+++ b/lib/View/Browse.php
@@ -224,8 +224,12 @@ class Turba_View_Browse
                                 // Get 'data' value if object type is image, the
                                 // direct value in other case.
                                 $objAttributes[$info_key] =
-                                    isset($attributes[$info_key]) &&
-                                        $attributes[$info_key]['type'] == 'image'
+                                    isset($targetDriver->map[$info_key]) &&
+                                        is_array($targetDriver->map[$info_key]) &&
+                                        isset($targetDriver->map[$info_key]['type']) &&
+                                        $targetDriver->map[$info_key]['type'] == 'image' &&
+                                        is_array($objectValue) &&
+                                        isset($objectValue['load']['data'])
                                         ? $objectValue['load']['data']
                                         : $objectValue;
                             }


### PR DESCRIPTION
# Fix: Null pointer exception in Turba Browse view when copying/moving contacts

## Problem

When copying or moving contacts in Turba, the following PHP 8.4 error occurs:

```
PHP ERROR: Trying to access array offset on null [line 229 of Browse.php]
```

This error occurs when:
1. Copying or moving a contact that has an attribute with type 'image'
2. The `$objectValue` returned by `$object->getValue($info_key)` is `null`
3. The code attempts to access `$objectValue['load']['data']` without null checks

Additionally, the code referenced an undefined variable `$attributes` which should have been `$targetDriver->map`.

## Root Cause

In `lib/View/Browse.php`, the code at line 226-229 (before fix) had two issues:

1. **Undefined variable**: Referenced `$attributes[$info_key]` which was never defined in the function scope. The correct variable is `$targetDriver->map[$info_key]` (as used in the condition above on line 220).

2. **Missing null safety**: When `$objectValue` is `null` and the type is 'image', the code attempted to access `$objectValue['load']['data']` without checking if `$objectValue` is an array or if the nested keys exist.

## Solution

Fixed both issues by:

1. **Replacing undefined variable**: Changed `$attributes` to `$targetDriver->map` to match the pattern used elsewhere in the function.

2. **Adding comprehensive null safety checks**:
   - Verify `$targetDriver->map[$info_key]` exists and is an array
   - Verify `$targetDriver->map[$info_key]['type']` exists before comparing
   - Verify `$objectValue` is an array before accessing it
   - Verify `$objectValue['load']['data']` exists before accessing it

If any of these conditions are not met, the code falls back to using `$objectValue` directly, which is the correct behavior for non-image types or when image data is not available.

## Changes

**File**: `vendor/horde/turba/lib/View/Browse.php`

**Lines changed**: 226-234

**Before**:
```php
$objAttributes[$info_key] =
    isset($attributes[$info_key]) &&
        $attributes[$info_key]['type'] == 'image'
        ? $objectValue['load']['data']
        : $objectValue;
```

**After**:
```php
$objAttributes[$info_key] =
    isset($targetDriver->map[$info_key]) &&
        is_array($targetDriver->map[$info_key]) &&
        isset($targetDriver->map[$info_key]['type']) &&
        $targetDriver->map[$info_key]['type'] == 'image' &&
        is_array($objectValue) &&
        isset($objectValue['load']['data'])
        ? $objectValue['load']['data']
        : $objectValue;
```

## Testing

The fix handles the following edge cases:
- ✅ `$objectValue` is `null`
- ✅ `$objectValue` is not an array
- ✅ `$objectValue['load']` doesn't exist
- ✅ `$objectValue['load']['data']` doesn't exist
- ✅ `$targetDriver->map[$info_key]` doesn't exist
- ✅ `$targetDriver->map[$info_key]` is not an array
- ✅ `$targetDriver->map[$info_key]['type']` doesn't exist

All cases now fall back gracefully to using `$objectValue` directly instead of throwing a fatal error.

## Impact

- **Severity**: Medium - Causes fatal errors when copying/moving certain contacts
- **Affected operations**: Copy and move operations in Turba browse view
- **User impact**: Prevents users from copying or moving contacts that have image attributes with null values
- **Backward compatibility**: ✅ Fully backward compatible - only adds safety checks