### PR TITLE
Refactor Turba_View_List

### DIFF
--- a/lib/View/List.php
+++ b/lib/View/List.php
@@ -85,21 +85,14 @@ class Turba_View_List implements Countable
      *
      * @var array
      */
-    public $variables = [];
-
-    /**
-     * A dummy form object.
-     *
-     * @var Horde_Form
-     */
-    public $form = null;
+    protected array $variables = [];
 
     /**
      * Which columns to render
      *
      * @var array
      */
-    public $columns;
+    protected $columns;
 
     /**
      * Constructs a new Turba_View_List object.
@@ -124,11 +117,22 @@ class Turba_View_List implements Countable
                 'Sort' => true,
             ];
         }
-        $this->columns = $columns;
         $this->list = $list;
         $this->setControls($controls);
         $this->renderer = Horde_Core_Ui_VarRenderer::factory(['turba', 'html']);
         $this->vars = new Horde_Variables();
+
+        $this->columns = $columns ?? [];
+        foreach ($this->columns as $column) {
+            $type = $GLOBALS['attributes'][$column]['type'];
+            if ($type == 'email') {
+                $type = 'html';
+                $params = [];
+            } else {
+                $params = $GLOBALS['attributes'][$column]['params'] ?? [];
+            }
+            $this->variables[] = Horde_Form::createVariable('', $column, $type, $params);
+        }
     }
 
     /**
@@ -174,9 +178,12 @@ class Turba_View_List implements Countable
         $driver = $GLOBALS['injector']
             ->getInstance('Turba_Factory_Driver')
             ->create(Turba::$source);
+
+        // used by actions.inc
         $hasDelete = $driver->hasPermission(Horde_Perms::DELETE);
         $hasEdit = $driver->hasPermission(Horde_Perms::EDIT);
-        $hasExport = ($GLOBALS['conf']['menu']['import_export'] && !empty($GLOBALS['cfgSources'][Turba::$source]['export']));
+        $hasExport = $GLOBALS['conf']['menu']['import_export'] && !empty($GLOBALS['cfgSources'][Turba::$source]['export']);
+
         $vars = Horde_Variables::getDefaultVariables();
 
         [$addToList, $addToListSources] = $this->getAddSources();
@@ -192,8 +199,11 @@ class Turba_View_List implements Countable
                 $min = $page * $perpage;
             }
             $max = $min + $perpage;
-            $start = ($page * $perpage) + 1;
+
+            // used by numPager.inc
+            $start = $page * $perpage + 1;
             $end = min($numitem, $start + $perpage - 1);
+
             $listHtml = $this->getPage($numDisplayed, $min, $max, $vars->get('page'));
             $crit = [];
             if ($session->get('turba', 'search_mode') == 'advanced') {

--- a/templates/browse/row.inc
+++ b/templates/browse/row.inc
@@ -58,58 +58,39 @@ if ($ob->hasValue('__key')) {
   <td<?php if ($this->showSort && $this->isSortColumn(0)) echo ' class="linedRowSelectedCol"' ?>><?php
 echo $cell;
 
+// TODO: The comment is wrong/irrelevant
 // We purposefully do this before the </td> so that if we end up including a
 // script file (say, for the IMP compose window), it's in a legal spot.
 //
 // Build the columns to display.
-$shown_columns = array();
-for ($c = 1; $c <= count($this->columns); $c++) {
-    $type = $GLOBALS['attributes'][$this->columns[$c - 1]]['type'];
-    $params = isset($GLOBALS['attributes'][$this->columns[$c - 1]]['params'])
-        ? $GLOBALS['attributes'][$this->columns[$c - 1]]['params']
-        : array();
-    if (!isset($this->variables[$this->columns[$c - 1]])) {
+$shown_columns = [];
+$c = 0;
+foreach ($this->columns as $column) {
+    $type = $GLOBALS['attributes'][$column]['type'];
+    if ($ob->hasValue($column)) {
+        $value = $ob->getValue($column);
         if ($type == 'email') {
-            $this->variables[$this->columns[$c - 1]] =
-                new Horde_Form_Variable(
-                    humanName: '',
-                    varName: $this->columns[$c - 1],
-                    type: Horde_Form_Type::create(type: 'html'),
-                    required: false
-                );
-        } else {
-            $this->variables[$this->columns[$c - 1]] =
-                new Horde_Form_Variable(
-                    humanName: '',
-                    varName: $this->columns[$c - 1],
-                    type: Horde_Form_Type::create(type: $type, params: $params),
-                    required: false
-                );
+            $value = Turba::formatEmailAddresses($value, $ob->getValue('name'));
         }
-    }
-    if ($ob->hasValue($this->columns[$c - 1])) {
-        $value = $ob->getValue($this->columns[$c - 1]);
-        if ($type == 'email') {
-            $value = Turba::formatEmailAddresses($value,
-                                                 $ob->getValue('name'));
-        }
-        $this->vars->set($this->columns[$c - 1], $value);
-        $shown_columns[$c] = $this->renderer->render(
-            $this->form,
-            $this->variables[$this->columns[$c - 1]],
-            $this->vars);
+        $this->vars->set($column, $value);
+        $value = $this->renderer->render(null, $this->variables[$c], $this->vars);
     } else {
-        $shown_columns[$c] = '&nbsp;';
+        $value = '&nbsp;';
     }
+    $shown_columns[] = $value;
+    ++$c;
 }
 
 echo '</td>';
-foreach ($shown_columns as $column => $value) {
+// start index with 1 as this is what isSortColumns() expects
+$c = 1;
+foreach ($shown_columns as $value) {
     echo '<td';
-    if ($this->showSort && $this->isSortColumn($column)) {
+    if ($this->showSort && $this->isSortColumn($c)) {
         echo ' class="linedRowSelectedCol"';
     }
     echo '>' . $value . '</td>';
+    ++$c;
 }
 ?>
 </tr>


### PR DESCRIPTION
Pre-initialize column variables via createVariable(), eliminating per-row overhead

- Move `Horde_Form_Variable` initialization from row.inc into constructor,
  leveraging `Horde_Form::createVariable()` instead of direct `getType()`
  calls, eliminating per-row per-column `isset()` checks and throwaway
  `Horde_Form` instantiations
- Normalize email column type to 'html' at initialization time
- Replace index-based for loop in row.inc with foreach over columns,
  using parallel index into pre-built variables array
- Remove now-unused `$form` property (was always null) and pass null
  directly to `renderer->render()`
- Restrict `$variables` and `$columns` to protected visibility
 
This fixes #25 (inability to view address books with customized columns).

**IMPORTANT: This code relies on the recent change ( see horde/Form@971e5ee) in `Horde_Form` class.**
