### PR TITLE
Fix/moving contacts between adressbooks

### DIFF
--- a/lib/Driver/Sql.php
+++ b/lib/Driver/Sql.php
@@ -449,7 +449,9 @@ class Turba_Driver_Sql extends Turba_Driver
         try {
             $this->_db->insertBlob(
                 $this->_params['table'],
-                array_combine($fields, $values)
+                array_combine($fields, $values),
+                $this->map['__key'] ?? null,
+                $attributes[$this->map['__key']] ?? null
             );
         } catch (Horde_Db_Exception $e) {
             Horde::log($e, 'ERR');

--- a/lib/View/Browse.php
+++ b/lib/View/Browse.php
@@ -221,13 +221,14 @@ class Turba_View_Browse
                                 || isset($targetDriver->map[$info_key]['attribute'])) {
                                 $objectValue = $object->getValue($info_key);
 
-                                // Get 'data' value if object type is image, the
-                                // direct value in other case.
+                                // Normalize image values from getValue() to raw
+                                // binary data before passing to add().
+                                $isImageAttribute = isset($GLOBALS['attributes'][$info_key])
+                                    && isset($GLOBALS['attributes'][$info_key]['type'])
+                                    && $GLOBALS['attributes'][$info_key]['type'] == 'image';
+
                                 $objAttributes[$info_key]
-                                    = isset($targetDriver->map[$info_key])
-                                        && is_array($targetDriver->map[$info_key])
-                                        && isset($targetDriver->map[$info_key]['type'])
-                                        && $targetDriver->map[$info_key]['type'] == 'image'
+                                    = $isImageAttribute
                                         && is_array($objectValue)
                                         && isset($objectValue['load']['data'])
                                         ? $objectValue['load']['data']


### PR DESCRIPTION
## Summary
This PR fixes two bugs when moving/copying contacts between address books in Turba (especially on PostgreSQL).
- Fix image/blob payload normalization in move/copy flow:
  image attributes could be passed as structured arrays (e.g. `['load']['data']`) instead of raw binary, which later caused blob write type errors.
- Fix PostgreSQL `lastval()` error on blob insert:
  Turba uses a manually generated string primary key (`object_id`), but blob insert path tried to read `lastInsertId()`/`lastval()`.
## Changes
### 1) Normalize image values before `add()` in browse move/copy
**File:** `vendor/horde/turba/lib/View/Browse.php`
- Detect image attributes via global attribute metadata (`type == 'image'`).
- If value is an image wrapper array with `load.data`, pass only raw binary data.
- Keep non-image attributes unchanged.
### 2) Pass explicit PK/id to blob insert in SQL driver
**File:** `vendor/horde/turba/lib/Driver/Sql.php`
- In `_add()`, call `insertBlob()` with:
  - primary key column (`__key` mapping, usually `object_id`)
  - already-known primary key value from attributes
- This avoids fallback to `lastInsertId()` in PostgreSQL sessions where no sequence `lastval()` exists.
## Why
Without these fixes, moving/copying contacts with photo/blob data could fail with:
- `TypeError: fwrite(): Argument #2 ($data) must be of type string, array given`
- `SQLSTATE[55000]: lastval ist in dieser Sitzung noch nicht definiert`
## Validation
- Reproduced move/copy scenario and verified successful add/move.
- Verified no more blob type errors in logs.
- Verified no more PostgreSQL `lastval()` errors in logs.
- Syntax checks:
  - `php -l vendor/horde/turba/lib/View/Browse.php`
  - `php -l vendor/horde/turba/lib/Driver/Sql.php`