### PR TITLE
Fix/avoid comma suffix after emails

### DIFF
--- a/lib/Driver.php
+++ b/lib/Driver.php
@@ -2800,20 +2800,33 @@ class Turba_Driver implements Countable
                     break;
 
                 case 'email':
-                    $message->email1address = $value;
+                    if (!self::_isPlaceholderEmail($value)) {
+                        $message->email1address = $value;
+                    }
                     break;
 
                 case 'homeEmail':
-                    $message->email2address = $value;
+                    if (!self::_isPlaceholderEmail($value)) {
+                        $message->email2address = $value;
+                    }
                     break;
 
                 case 'workEmail':
-                    $message->email3address = $value;
+                    if (!self::_isPlaceholderEmail($value)) {
+                        $message->email3address = $value;
+                    }
                     break;
 
                 case 'emails':
+                    if (self::_isPlaceholderEmail($value)) {
+                        break;
+                    }
                     $address = 1;
                     foreach (explode(',', $value) as $email) {
+                        $email = trim($email);
+                        if (self::_isPlaceholderEmail($email)) {
+                            continue;
+                        }
                         while ($address <= 3
                                && $message->{'email' . $address . 'address'}) {
                             $address++;
@@ -2892,6 +2905,29 @@ class Turba_Driver implements Countable
     }
 
     /**
+     * Detect placeholder ActiveSync email values that should not be stored or
+     * exported.
+     *
+     * @param mixed $value  The email value to check.
+     *
+     * @return boolean  True if the value is empty or comma-only.
+     */
+    protected static function _isPlaceholderEmail($value)
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        if (!is_string($value)) {
+            return false;
+        }
+
+        $value = trim($value);
+
+        return $value === '' || preg_match('/^,+$/', $value);
+    }
+
+    /**
      * Convert an ActiveSync contact message into a hash suitable for
      * importing via self::add().
      *
@@ -2940,21 +2976,29 @@ class Turba_Driver implements Countable
         }
 
         /* Email addresses */
-        $hash['emails'] = [];
+        $emailParts = [];
         if (!$message->isGhosted('email1address')) {
             $e = Horde_Icalendar_Vcard::getBareEmail($message->email1address);
-            $hash['emails'][] = $hash['email'] = $e ? $e : '';
-
+            $hash['email'] = $e ?: '';
+            if ($e) {
+                $emailParts[] = $e;
+            }
         }
         if (!$message->isGhosted('email2address')) {
             $e = Horde_Icalendar_Vcard::getBareEmail($message->email2address);
-            $hash['emails'][] = $hash['homeEmail'] = $e ? $e : '';
+            $hash['homeEmail'] = $e ?: '';
+            if ($e) {
+                $emailParts[] = $e;
+            }
         }
         if (!$message->isGhosted('email3address')) {
             $e = Horde_Icalendar_Vcard::getBareEmail($message->email3address);
-            $hash['emails'][] = $hash['workEmail'] = $e ? $e : '';
+            $hash['workEmail'] = $e ?: '';
+            if ($e) {
+                $emailParts[] = $e;
+            }
         }
-        $hash['emails'] = implode(',', $hash['emails']);
+        $hash['emails'] = $emailParts ? implode(',', $emailParts) : '';
 
         /* Categories */
         if (!$message->isGhosted('categories') && empty($message->categories)) {

--- a/lib/Object.php
+++ b/lib/Object.php
@@ -260,6 +260,12 @@ class Turba_Object
         // is better than dropping them.
         foreach ($this->_attributeFields as $type => $values) {
             foreach ($values as $value) {
+                if ($type === 'email'
+                    && (!is_string($value)
+                        || $value === ''
+                        || preg_match('/^,*$/', trim($value)))) {
+                    continue;
+                }
                 foreach (array_keys($this->driver->map) as $attribute) {
                     if (isset($attributes[$attribute])
                         && $attributes[$attribute]['type'] == $type


### PR DESCRIPTION
## Summary

Fixes ghost email values (notably `,,`) on contacts synchronized via ActiveSync, especially from iOS devices. The issue came from Turba’s import, export, and fallback logic for unmapped email attributes—not from address book configuration in `backends.local.php`.

## Problem

Contact sync over ActiveSync repeatedly produced incorrect email fields:

- Contacts with only first and last name showed an email on the iPhone with the visible value `,,`.
- In other cases, duplicate addresses or variants with a trailing `,,` appeared (e.g. `name@example.com,,`).
- Email changes made on the phone often did not behave reliably.

Sync itself worked; mapping the three Exchange fields `Email1Address`–`Email3Address` to Turba attributes was fragile.

## Background

### ActiveSync and Turba

Exchange ActiveSync exposes three fixed email slots. Turba maps them to `email`, `homeEmail`, and `workEmail` (for `localsql`, to `object_email`, `object_homeemail`, and `object_workemail`). Turba also has an `emails` attribute as a comma-separated list. In the default schema it has no dedicated column, but the ActiveSync path still sets it.

### Import (`fromASContact`)

Previously, all three slots were collected into an array and joined with `implode(',', …)` into `emails`, **including empty strings**. Three empty slots become `,,`. With only slot 1 filled, the result could be e.g. `name@example.com,,`.

### Save (`Turba_Object::ensureAttributes`)

When `emails` is not mapped in the backend `map`, the value goes into the `_attributeFields` buffer. `ensureAttributes()` writes it into the first empty mapped email field—often `object_email` or `object_homeemail`. Placeholders like `,,` or `name@example.com,,` could be persisted that way.

### Export (`toASContact`)

Single fields and `emails` (via `explode`) both fill the same three EAS slots. Placeholders and empty segments could be sent back to the device.

## Solution

No schema or config changes—Turba code only. Goal: stop creating, storing, and exporting new ghost `,,` values. **Existing database rows are not migrated**; legacy bad values remain until manual cleanup or re-sync after the server is updated.

### 1. Import (`Turba_Driver::fromASContact`)

- Only non-empty addresses (after `getBareEmail()`) go into `emails`.
- Set `emails` only when at least one address exists; otherwise an empty string.
- Empty slots no longer produce `,,`.

### 2. Export (`Turba_Driver::toASContact`)

- New helper `_isPlaceholderEmail()`: empty or comma-only values (e.g. `,,`) are not exported.
- Applies to `email`, `homeEmail`, `workEmail`, and `emails` (including `trim` and skipping empty `explode` segments).

### 3. Fallback fill (`Turba_Object::ensureAttributes`)

- Email buffer values that are empty or comma-only are not written into mapped fields.

## Changed files

- `lib/Driver.php` — `fromASContact`, `toASContact`, `_isPlaceholderEmail()`
- `lib/Object.php` — `ensureAttributes()`

## Out of scope

- Address book multiplexing / `activesync_no_multiplex`
- `backends.local.php` / SQL schema
- Automatic cleanup of existing contacts in the database
- CardDAV or other protocols outside the ActiveSync path

## Testing recommendations

1. Create a contact on the iPhone with only first and last name → after sync, no email field with `,,`.
2. Contact with one email → one address, no trailing `,,`.
3. Contact with multiple email fields → slots 1–3 correct, no duplicates from empty segments.
4. Contact created in Turba with name only → after first phone sync/update, no new ghost emails.
5. Optional: after deploy, re-sync contacts on the device if old `,,` values only remain in the client cache.

## Risks / notes

- The change lives under `vendor/horde/turba` and may need reapplication after `composer update`, or submission upstream.
- Ghosting behavior is unchanged; only empty and comma-only values are filtered.
- Already stored bad values are not fixed by this PR; handle separately if needed.