### PR TITLE
Fix/cleanup after addressbook deletion

### DIFF
--- a/config/prefs.php
+++ b/config/prefs.php
@@ -70,28 +70,7 @@ $_prefs['sync_books'] = [
         $ui->prefs['sync_books']['enum'] = $enum;
     },
     'on_change' => function () {
-        if ($GLOBALS['conf']['activesync']['enabled']) {
-            try {
-                $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
-                $sm->setLogger($GLOBALS['injector']->getInstance('Horde_Log_Logger'));
-                $devices = $sm->listDevices($GLOBALS['registry']->getAuth());
-                foreach ($devices as $device) {
-                    $device_ob = $sm->loadDeviceInfo($device['device_id'], $device['device_user']);
-                    if (!$GLOBALS['prefs']->getValue('activesync_no_multiplex')
-                        || ($device_ob->multiplex & Horde_ActiveSync_Device::MULTIPLEX_CONTACTS)) {
-                        $map = $sm->getFolderUidToBackendIdMap();
-                        $sm->removeState([
-                            'devId' => $device['device_id'],
-                            'id' => (!empty($map[Horde_Core_ActiveSync_Driver::CONTACTS_FOLDER_UID]) ? $map[Horde_Core_ActiveSync_Driver::CONTACTS_FOLDER_UID] : Horde_Core_ActiveSync_Driver::CONTACTS_FOLDER_UID),
-                            'user' => $GLOBALS['registry']->getAuth(),
-                        ]);
-                    }
-                }
-                $GLOBALS['notification']->push(_("All state removed for your ActiveSync devices. They will resynchronize next time they connect to the server."));
-            } catch (Horde_ActiveSync_Exception $e) {
-                $GLOBALS['notification']->push(_("There was an error communicating with the ActiveSync server: %s"), $e->getMessage(), 'horde.error');
-            }
-        }
+        $GLOBALS['injector']->getInstance('Turba_Api')->resetActiveSyncContactsState(true);
     },
 ];
 

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -2295,6 +2295,71 @@ class Turba_Api extends Horde_Registry_Api
     }
 
     /**
+     * Remove an address book from the sync_books preference.
+     *
+     * @param string $id  The addressbook id.
+     *
+     * @return boolean  True if the preference was updated.
+     * @since 4.2.0
+     */
+    public function removeSyncBook($id)
+    {
+        global $prefs;
+
+        $sync = @unserialize($prefs->getValue('sync_books'));
+        if (empty($sync) || !in_array($id, $sync, true)) {
+            return false;
+        }
+
+        $sync = array_values(array_diff($sync, [$id]));
+        $prefs->setValue('sync_books', serialize($sync));
+        $this->resetActiveSyncContactsState(true);
+
+        return true;
+    }
+
+    /**
+     * Reset ActiveSync state for all contact folders on the user's devices.
+     *
+     * @param boolean $notify  Push a notification on success or failure?
+     *
+     * @since 4.2.0
+     */
+    public function resetActiveSyncContactsState($notify = false)
+    {
+        global $conf, $injector, $notification, $prefs;
+
+        if (empty($conf['activesync']['enabled'])) {
+            return;
+        }
+
+        try {
+            $sm = $injector->getInstance('Horde_ActiveSyncState');
+            $sm->setLogger($injector->getInstance('Horde_Log_Logger'));
+            $devices = $sm->listDevices($GLOBALS['registry']->getAuth());
+            foreach ($devices as $device) {
+                $device_ob = $sm->loadDeviceInfo($device['device_id'], $device['device_user']);
+                if (!$prefs->getValue('activesync_no_multiplex')
+                    || ($device_ob->multiplex & Horde_ActiveSync_Device::MULTIPLEX_CONTACTS)) {
+                    $map = $sm->getFolderUidToBackendIdMap();
+                    $sm->removeState([
+                        'devId' => $device['device_id'],
+                        'id' => (!empty($map[Horde_Core_ActiveSync_Driver::CONTACTS_FOLDER_UID]) ? $map[Horde_Core_ActiveSync_Driver::CONTACTS_FOLDER_UID] : Horde_Core_ActiveSync_Driver::CONTACTS_FOLDER_UID),
+                        'user' => $GLOBALS['registry']->getAuth(),
+                    ]);
+                }
+            }
+            if ($notify) {
+                $notification->push(_("All state removed for your ActiveSync devices. They will resynchronize next time they connect to the server."));
+            }
+        } catch (Horde_ActiveSync_Exception $e) {
+            if ($notify) {
+                $notification->push(_("There was an error communicating with the ActiveSync server: %s"), $e->getMessage(), 'horde.error');
+            }
+        }
+    }
+
+    /**
      * Delete the specified addressbook.
      *
      * @param string $id  The addressbook id.
@@ -2302,6 +2367,8 @@ class Turba_Api extends Horde_Registry_Api
      */
     public function deleteAddressbook($id)
     {
+        $this->removeSyncBook($id);
+
         $share = $GLOBALS['injector']
             ->getInstance('Turba_Factory_Driver')
             ->create($id);
@@ -2352,8 +2419,10 @@ class Turba_Api extends Horde_Registry_Api
      */
     protected function _getSources($sources, $synchronize = false, $end = false)
     {
+        $fromPrefs = empty($sources);
+
         /* Get default address book from user preferences. */
-        if (empty($sources)) {
+        if ($fromPrefs) {
             $sources = @unserialize($GLOBALS['prefs']->getValue('sync_books'));
         } elseif (!is_array($sources)) {
             $sources = [$sources];
@@ -2361,15 +2430,39 @@ class Turba_Api extends Horde_Registry_Api
 
         if (empty($sources)) {
             $sources = [Turba::getDefaultAddressbook()];
-            if (empty($sources)) {
+            if (empty($sources[0])) {
                 throw new Turba_Exception(_("No address book specified"));
             }
         }
 
+        $valid = [];
         foreach ($sources as $val) {
             if (!strlen($val) || !isset($GLOBALS['cfgSources'][$val])) {
-                throw new Turba_Exception(sprintf(_("Invalid address book: %s"), $val));
+                if (!$fromPrefs) {
+                    throw new Turba_Exception(sprintf(_("Invalid address book: %s"), $val));
+                }
+                continue;
             }
+            $valid[] = $val;
+        }
+
+        if (empty($valid)) {
+            if ($fromPrefs) {
+                $default = Turba::getDefaultAddressbook();
+                if (empty($default)) {
+                    throw new Turba_Exception(_("No address book specified"));
+                }
+                $valid = [$default];
+            } else {
+                throw new Turba_Exception(sprintf(_("Invalid address book: %s"), $sources[0]));
+            }
+        }
+
+        if ($fromPrefs && $valid != $sources) {
+            $GLOBALS['prefs']->setValue('sync_books', serialize(array_values($valid)));
+        }
+
+        foreach ($valid as $val) {
             if ($synchronize) {
                 $GLOBALS['injector']
                     ->getInstance('Turba_Factory_Driver')
@@ -2378,7 +2471,7 @@ class Turba_Api extends Horde_Registry_Api
             }
         }
 
-        return $sources;
+        return $valid;
     }
 
     /**

--- a/lib/Form/DeleteAddressBook.php
+++ b/lib/Form/DeleteAddressBook.php
@@ -66,6 +66,9 @@ class Turba_Form_DeleteAddressBook extends Horde_Form
             }
         }
 
+        $shareName = $this->_addressbook->getName();
+        $GLOBALS['registry']->contacts->removeSyncBook($shareName);
+
         // Address book successfully deleted from backend, remove the share.
         try {
             $GLOBALS['injector']

--- a/lib/Turba.php
+++ b/lib/Turba.php
@@ -688,6 +688,7 @@ class Turba
                     'horde.message'
                 );
                 try {
+                    $registry->contacts->removeSyncBook($name);
                     $injector->getInstance('Turba_Shares')->removeShare($shares[$name]);
                 } catch (Horde_Share_Exception $e) {
                     Horde::log($e, 'ERR');


### PR DESCRIPTION
# Clean up `sync_books` when address books are deleted

## Summary

- Remove deleted address book IDs from the `sync_books` user preference automatically on every delete path (web UI, API/RPC, and automatic vbook removal).
- Reset ActiveSync contact folder state when `sync_books` changes, matching the existing behavior for manual preference edits.
- Self-heal stale `sync_books` entries on the next contact sync instead of failing with `Invalid address book`.

## Problem

Turba stores the list of address books to export via ActiveSync in the `sync_books` preference. When a new book is created through ActiveSync, `addAddressbook()` appends its share ID to that list — but none of the delete paths removed the ID again.

The preferences UI only displays books that still exist, so stale IDs can remain in the stored preference unnoticed. On the next contact sync, `_getSources()` loaded the preference and threw `Invalid address book: <id>`. ActiveSync logged the error and returned an empty contact list (Status 1, no `POOMCONTACTS` data), which manifested as empty contacts in Outlook while mail and calendar continued to work.

## Solution

1. **`Turba_Api::removeSyncBook($id)`** — remove one share ID from `sync_books`; if the preference changed, call the ActiveSync contact state reset.
2. **`Turba_Api::resetActiveSyncContactsState($notify)`** — centralize the device state reset previously duplicated in `config/prefs.php` `on_change`.
3. **Call `removeSyncBook()` from all delete paths:**
   - `Turba_Api::deleteAddressbook()` (RPC / ActiveSync connector)
   - `Turba_Form_DeleteAddressBook::execute()` (web UI)
   - `Turba::getConfigFromShares()` (automatic removal of orphaned virtual address books)
4. **`Turba_Api::_getSources()`** — when loading from `sync_books`, skip IDs that no longer exist in `$cfgSources`, persist the pruned list, and continue with valid books. Explicit caller-supplied source IDs still fail fast with an exception.

## Files changed

| File | Change |
|------|--------|
| `lib/Api.php` | New `removeSyncBook()`, `resetActiveSyncContactsState()`; cleanup in `deleteAddressbook()`; self-healing in `_getSources()` |
| `lib/Form/DeleteAddressBook.php` | Call `removeSyncBook()` before `removeShare()` |
| `lib/Turba.php` | Call `removeSyncBook()` when removing orphaned vbooks |
| `config/prefs.php` | Refactor `sync_books` `on_change` to use `resetActiveSyncContactsState(true)` |

## Test plan

- [ ] Create an address book with ActiveSync sync enabled; confirm it appears in `sync_books` (Turba preferences or DB).
- [ ] Delete that address book via the Turba web UI; confirm its ID is removed from `sync_books` and ActiveSync devices receive a resync notification.
- [ ] With two books in `sync_books`, delete one; confirm the remaining book still syncs contacts to Outlook/iOS.
- [ ] Manually insert a non-existent share ID into `sync_books`; trigger a contact sync; confirm the stale ID is pruned, sync succeeds, and no `Invalid address book` error appears in the ActiveSync log.
- [ ] Change `sync_books` manually in Turba preferences; confirm ActiveSync contact state is still reset and the success notification is shown (unchanged behavior, refactored implementation).
- [ ] Delete an address book via the API (`contacts/deleteAddressbook` RPC) if available; confirm the same `sync_books` cleanup occurs.
