### PR TITLE
fix(security): restrict unserialize allowed_classes (ZDI-20-1051)

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -150,7 +150,7 @@ class Turba_Api extends Horde_Registry_Api
             $driver = $injector->getInstance('Turba_Factory_Driver');
 
             foreach (Turba::listShares(true) as $uid => $share) {
-                $params = @unserialize($share->get('params'));
+                $params = @unserialize($share->get('params'), ['allowed_classes' => false]);
                 if (!empty($params['source'])) {
                     try {
                         if ($driver->create($uid)->checkDefaultShare($share, $cfgSources[$params['source']])) {
@@ -2053,7 +2053,7 @@ class Turba_Api extends Horde_Registry_Api
                     $contact_shares = $this->listShares(Horde_Perms::SHOW);
                 }
                 foreach ($contact_shares as $id => $share) {
-                    $params = @unserialize($share->get('params'));
+                    $params = @unserialize($share->get('params'), ['allowed_classes' => false]);
                     if ($params['source'] == $key) {
                         $owners[] = $params['name'];
                     }
@@ -2198,7 +2198,7 @@ class Turba_Api extends Horde_Registry_Api
             return [];
         }
         [$source, ] = explode(':', $gid);
-        $members = @unserialize($entry['members']);
+        $members = @unserialize($entry['members'], ['allowed_classes' => false]);
         if (!is_array($members)) {
             return [];
         }
@@ -2213,7 +2213,7 @@ class Turba_Api extends Horde_Registry_Api
             if (strpos($member, ':') !== false) {
                 [$newSource, $uid] = explode(':', $member);
                 if (!empty($contact_shares[$newSource])) {
-                    $params = @unserialize($contact_shares[$newSource]->get('params'));
+                    $params = @unserialize($contact_shares[$newSource]->get('params'), ['allowed_classes' => false]);
                     $newSource = $params['source'];
                     $member = $uid;
                     $db[$newSource] = empty($sources[$newSource]['params']['sql'])
@@ -2286,7 +2286,7 @@ class Turba_Api extends Horde_Registry_Api
         $shareName = $share->getName();
 
         if (!empty($params['synchronize'])) {
-            $sync = @unserialize($prefs->getValue('sync_books'));
+            $sync = @unserialize($prefs->getValue('sync_books'), ['allowed_classes' => false]);
             $sync[] = $shareName;
             $prefs->setValue('sync_books', serialize($sync));
         }
@@ -2306,7 +2306,7 @@ class Turba_Api extends Horde_Registry_Api
     {
         global $prefs;
 
-        $sync = @unserialize($prefs->getValue('sync_books'));
+        $sync = @unserialize($prefs->getValue('sync_books'), ['allowed_classes' => false]);
         if (empty($sync) || !in_array($id, $sync, true)) {
             return false;
         }
@@ -2423,7 +2423,7 @@ class Turba_Api extends Horde_Registry_Api
 
         /* Get default address book from user preferences. */
         if ($fromPrefs) {
-            $sources = @unserialize($GLOBALS['prefs']->getValue('sync_books'));
+            $sources = @unserialize($GLOBALS['prefs']->getValue('sync_books'), ['allowed_classes' => false]);
         } elseif (!is_array($sources)) {
             $sources = [$sources];
         }

--- a/lib/Driver.php
+++ b/lib/Driver.php
@@ -3352,7 +3352,7 @@ class Turba_Driver implements Countable
      */
     public function checkDefaultShare(Horde_Share_Object $share, array $srcconfig)
     {
-        $params = @unserialize($share->get('params'));
+        $params = @unserialize($share->get('params'), ['allowed_classes' => false]);
         if (!isset($params['default'])) {
             $params['default'] = ($params['name'] == $GLOBALS['registry']->getAuth());
             $share->set('params', serialize($params));

--- a/lib/Driver/Share.php
+++ b/lib/Driver/Share.php
@@ -181,7 +181,7 @@ class Turba_Driver_Share extends Turba_Driver
      */
     protected function _getContactOwner()
     {
-        $params = @unserialize($this->_share->get('params'));
+        $params = @unserialize($this->_share->get('params'), ['allowed_classes' => false]);
         if (!empty($params['name'])) {
             return $params['name'];
         }

--- a/lib/Object/Group.php
+++ b/lib/Object/Group.php
@@ -95,7 +95,7 @@ class Turba_Object_Group extends Turba_Object
         }
 
         // Explode members.
-        $members = @unserialize($this->attributes['__members']);
+        $members = @unserialize($this->attributes['__members'], ['allowed_classes' => false]);
         if (!is_array($members)) {
             $members = [];
         }
@@ -118,7 +118,7 @@ class Turba_Object_Group extends Turba_Object
      */
     public function removeMember($contactId, $sourceId = null)
     {
-        $members = @unserialize($this->attributes['__members']);
+        $members = @unserialize($this->attributes['__members'], ['allowed_classes' => false]);
 
         if (is_null($sourceId) || $sourceId == $this->getSource()) {
             $i = array_search($contactId, $members);
@@ -142,7 +142,7 @@ class Turba_Object_Group extends Turba_Object
      */
     public function count()
     {
-        $children = @unserialize($this->attributes['__members']);
+        $children = @unserialize($this->attributes['__members'], ['allowed_classes' => false]);
         if (!is_array($children)) {
             return 0;
         } else {

--- a/lib/Turba.php
+++ b/lib/Turba.php
@@ -152,7 +152,7 @@ class Turba
      */
     public static function getPreferredSortOrder()
     {
-        return @unserialize($GLOBALS['prefs']->getValue('sortorder'));
+        return @unserialize($GLOBALS['prefs']->getValue('sortorder'), ['allowed_classes' => false]);
     }
 
     /**
@@ -581,7 +581,7 @@ class Turba
 
             $personal |= ($share->get('owner') == $auth_user);
 
-            $params = @unserialize($share->get('params'));
+            $params = @unserialize($share->get('params'), ['allowed_classes' => false]);
             if (empty($params['source']) && !empty($all_shares)) {
                 $params['source'] = $all_shares;
             }
@@ -711,7 +711,7 @@ class Turba
         // Require a fresh config file.
         $cfgSources = self::availableSources();
 
-        $params = @unserialize($share->get('params'));
+        $params = @unserialize($share->get('params'), ['allowed_classes' => false]);
         $newConfig = $cfgSources[$params['source']];
         $newConfig['params']['config'] = $cfgSources[$params['source']];
         $newConfig['params']['config']['params']['share'] = $share;


### PR DESCRIPTION
## Summary

Follow-up to horde/imp#7

Deserialization restricted to data-only with no class support for:
sortorder, sync_books, share params, group members