### PR TITLE
refactor(session): drop $_SESSION read for has_share

### DIFF
--- a/lib/Turba.php
+++ b/lib/Turba.php
@@ -131,7 +131,7 @@ class Turba
             return $defaultAddressbook;
         }
         /* In case of shares select first user owned address book as default */
-        if (!empty($_SESSION['turba']['has_share'])) {
+        if (!empty($GLOBALS['session']->get('turba', 'has_share'))) {
             try {
                 $owned_shares = self::listShares(true);
                 if (count($owned_shares)) {


### PR DESCRIPTION
Single residual superglobal read in Turba::getDefaultAddressbook.
Every other site in the codebase (search.php, lib/Application.php,
Turba.php:739) reads via $session->get('turba', 'has_share'). Match
the rest. Removes the last superglobal read in turba and unblocks
the eventual retirement of horde/Core's Horde_Shutdown::addFinal()
mirror.
