### PR TITLE
fix(turba): harden contacts search field mapping for ActiveSync

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -1246,6 +1246,16 @@ class Turba_Api extends Horde_Registry_Api
         if (!count($opts['sources'])) {
             $opts['sources'] = [Turba::getDefaultAddressbook()];
             if (!empty($opts['fields']) && empty($opts['fields'][$opts['sources'][0]])) {
+                // Callers may pass 'fields' in two shapes:
+                //   - flat field list: ['firstname', 'lastname']
+                //   - keyed per source: ['someSource' => ['firstname', ...]]
+                // When the original sources have all been filtered out we
+                // need to attach a sensible field list to the fallback
+                // default source. For the keyed shape, copy the first
+                // source's field list rather than the whole keyed map
+                // (assigning the whole map here would nest arrays under
+                // $opts['fields'][$default] and crash the criteria loop
+                // below on PHP 8).
                 $firstKey = array_key_first($opts['fields']);
                 if ($firstKey !== null
                     && is_string($firstKey)
@@ -1301,6 +1311,11 @@ class Turba_Api extends Horde_Registry_Api
                 if ($checkName) {
                     if (isset($opts['fields'][$source])) {
                         foreach ($opts['fields'][$source] as $field) {
+                            // Defense in depth: even if the shape detection
+                            // above falls through to the legacy assignment,
+                            // a per-source list could still contain a stray
+                            // nested entry from a malformed caller. Skipping
+                            // non-string entries keeps $criteria flat.
                             if (!is_string($field)) {
                                 continue;
                             }

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -1246,7 +1246,14 @@ class Turba_Api extends Horde_Registry_Api
         if (!count($opts['sources'])) {
             $opts['sources'] = [Turba::getDefaultAddressbook()];
             if (!empty($opts['fields']) && empty($opts['fields'][$opts['sources'][0]])) {
-                $opts['fields'][$opts['sources'][0]] = $opts['fields'];
+                $firstKey = array_key_first($opts['fields']);
+                if ($firstKey !== null
+                    && is_string($firstKey)
+                    && is_array($opts['fields'][$firstKey])) {
+                    $opts['fields'][$opts['sources'][0]] = $opts['fields'][$firstKey];
+                } else {
+                    $opts['fields'][$opts['sources'][0]] = $opts['fields'];
+                }
             }
         }
 
@@ -1294,6 +1301,9 @@ class Turba_Api extends Horde_Registry_Api
                 if ($checkName) {
                     if (isset($opts['fields'][$source])) {
                         foreach ($opts['fields'][$source] as $field) {
+                            if (!is_string($field)) {
+                                continue;
+                            }
                             $criteria[$field] = $trimname;
                         }
                     }


### PR DESCRIPTION
## Summary
- Fix `Turba_Api::search()` when defaulting address book sources leaves a nested `fields` structure
- Skip non-string entries in per-source search field lists (prevents PHP 8 TypeError)

## Motivation
ActiveSync `ResolveRecipients` calls `contacts/search` with per-source field maps. When all configured sources are filtered out, Turba assigned the entire keyed `fields` array to the default source. That produced nested arrays and `$criteria[$field]` crashes (`Cannot access offset of type array on array`).

## Changes
- When falling back to the default address book, copy the first source's field list instead of the whole keyed map when appropriate
- Guard the search criteria loop with `is_string($field)`

## Test plan
- [ ] ActiveSync `ResolveRecipients` while composing a meeting invite on iOS (no Turba TypeError in `horde.log`)
- [ ] Turba contact search in web UI still returns expected results
- [ ] Empty/invalid source list falls back to default address book search
