### PR TITLE
fix(turba): throw Horde_Exception_NotFound for missing contacts in API

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -883,6 +883,8 @@ class Turba_Api extends Horde_Registry_Api
      *
      * @return mixed  The requested data.
      * @throws Turba_Exception
+     * @throws Horde_Exception_NotFound  If no contact with the given UID
+     *                                   exists in the requested source(s).
      */
     public function export($uid, $contentType, $sources = null, $fields = null, array $options = [])
     {
@@ -947,7 +949,12 @@ class Turba_Api extends Horde_Registry_Api
             }
         }
 
-        throw new Turba_Exception(sprintf(_("Object %s not found."), $uid));
+        /* Throw Horde_Exception_NotFound (not a generic Turba_Exception) so
+         * consumers like the ActiveSync exporter can distinguish a
+         * permanently missing contact (e.g. moved to another address book)
+         * from a temporary backend failure and drop it from the pending
+         * change list instead of retrying forever. */
+        throw new Horde_Exception_NotFound(sprintf(_("Object %s not found."), $uid));
     }
 
     /**
@@ -1086,6 +1093,8 @@ class Turba_Api extends Horde_Registry_Api
      *
      * @return boolean  Success or failure.
      * @throws Turba_Exception
+     * @throws Horde_Exception_NotFound  If no contact with the given UID
+     *                                   exists in the requested source(s).
      */
     public function replace($uid, $content, $contentType, $sources = null)
     {
@@ -1159,7 +1168,9 @@ class Turba_Api extends Horde_Registry_Api
             return $object->store();
         }
 
-        throw new Turba_Exception(sprintf(_("Object %s not found."), $uid));
+        /* See export(): NotFound lets ActiveSync distinguish a missing
+         * contact from a temporary backend error. */
+        throw new Horde_Exception_NotFound(sprintf(_("Object %s not found."), $uid));
     }
 
     /**


### PR DESCRIPTION
## Summary
- `Turba_Api::export()` and `Turba_Api::replace()` now throw `Horde_Exception_NotFound` instead of a generic `Turba_Exception` when no contact with the given UID exists in the searched sources.

## Motivation
Moving a contact out of an ActiveSync-synced address book while its add/change was still pending in a sync batch caused an endless sync loop: the export failed with a generic `Turba_Exception`, which `Horde_Core_ActiveSync_Driver::getMessage()` rethrows as `Horde_ActiveSync_Exception`. The sync exporter treats that as a transient backend error and keeps the change in `sync_pending`, so the device retried the same broken change on every SYNC request:

    ERR: Object 20140927180940.xxx@example.com not found.
    ERR: Unknown backend error skipping message: Object 20140927180940.xxx@example.com not found.

## Changes
- Throw `Horde_Exception_NotFound` for the "Object %s not found." case in `export()` and `replace()`, matching the Kronolith and Nag APIs (their `getByUID()` throws `Horde_Exception_NotFound`). The ActiveSync exporter already handles `NotFound` by dropping the stale entry from the pending change list and continuing; the client copy is then removed through the regular history delete entry.
- Document the new exception in both docblocks.

`Horde_Exception_NotFound` is a `Horde_Exception` subclass, so callers catching `Horde_Exception` are unaffected. The only in-tree consumer of `contacts/export` / `contacts/replace` is the ActiveSync connector.

## Test plan
- [ ] Move a contact from an ActiveSync-synced address book to a non-synced one while the collection has pending changes.
- [ ] Verify the device log shows a single `Message gone or error reading message from server` notice instead of a repeating `Unknown backend error skipping message` loop.
- [ ] Verify the contact is removed from the device and the collection continues syncing normally.
